### PR TITLE
Break location field out into subfields

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,5 +15,8 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[_includes/*.html]
+insert_final_newline = false
+
 [*.md]
 trim_trailing_whitespace = false

--- a/_includes/gallery-list-item.html
+++ b/_includes/gallery-list-item.html
@@ -2,7 +2,7 @@
   <h2 class="title">
     <time datetime="{{ trip.date | date: "%Y-%m-%d" }}">{{ trip.date | date: "%b %d, %Y" }}</time>
     <a rel="bookmark" href="{{ site.url }}{{ trip.url }}">{{ trip.title }}</a>
-    {% if trip.location %}<span class="where">in {{ trip.location }}</span>{% endif %}
+    {% if trip.location %}<span class="where">in {% include location.html location=trip.location %}</span>{% endif %}
   </h2>
 
   {% if trip.summary %}

--- a/_includes/gallery-list-item.html
+++ b/_includes/gallery-list-item.html
@@ -2,7 +2,7 @@
   <h2 class="title">
     <time datetime="{{ trip.date | date: "%Y-%m-%d" }}">{{ trip.date | date: "%b %d, %Y" }}</time>
     <a rel="bookmark" href="{{ site.url }}{{ trip.url }}">{{ trip.title }}</a>
-    {% if trip.location %}<span class="where">in {% include location.html location=trip.location %}</span>{% endif %}
+    {% if trip.location %}<span class="where">{% include location.html location=trip.location %}</span>{% endif %}
   </h2>
 
   {% if trip.summary %}

--- a/_includes/location-microformat.html
+++ b/_includes/location-microformat.html
@@ -1,0 +1,10 @@
+{% capture location_full %}
+  {% if include.location.locality %}
+    <span class="h-locality">{{ include.location.locality }}</span>{% if include.location.region or include.location.country %}, {% endif %}
+  {% endif %}
+  {% if include.location.region %}
+    <span class="h-region">{{ include.location.region }}</span>{% if include.location.country %}, {% endif %}
+  {% endif %}
+  {% if include.location.country %}<span class="h-country-name">{{ include.location.country }}</span>{% endif %}
+  {% if include.location.locality == null and include.location.region == null and include.location.country == null and include.location %}{{ include.location }}{% endif %}
+{% endcapture %}{{ location_full | strip_newlines | replace:'  ',' ' | replace:'  ',' ' | replace:'  ',' ' | replace:'  ',' ' }}

--- a/_includes/location-microformat.html
+++ b/_includes/location-microformat.html
@@ -1,4 +1,5 @@
 {% capture location_full %}
+  {% if include.location.prep %}{{ include.location.prep }} {% else %}in {% endif %}
   {% if include.location.locality %}
     <span class="h-locality">{{ include.location.locality }}</span>{% if include.location.region or include.location.country %}, {% endif %}
   {% endif %}
@@ -6,5 +7,5 @@
     <span class="h-region">{{ include.location.region }}</span>{% if include.location.country %}, {% endif %}
   {% endif %}
   {% if include.location.country %}<span class="h-country-name">{{ include.location.country }}</span>{% endif %}
-  {% if include.location.locality == null and include.location.region == null and include.location.country == null and include.location %}{{ include.location }}{% endif %}
+  {% if include.location.locality == null and include.location.region == null and include.location.country == null and include.location.place %}<span class="h-card"><span class="p-name">{{ include.location.place }}</span></span>{% endif %}
 {% endcapture %}{{ location_full | strip_newlines | replace:'  ',' ' | replace:'  ',' ' | replace:'  ',' ' | replace:'  ',' ' }}

--- a/_includes/location.html
+++ b/_includes/location.html
@@ -1,4 +1,5 @@
 {% capture location_full %}
+{% if include.location.prep %}{{ include.location.prep }} {% else %}in {% endif %}
 {% if include.location.locality %}
 {{ include.location.locality }}{% if include.location.region or include.location.country %}, {% endif %}
 {% endif %}
@@ -6,5 +7,5 @@
 {{ include.location.region }}{% if include.location.country %}, {% endif %}
 {% endif %}
 {% if include.location.country %}{{ include.location.country }}{% endif %}
-{% if include.location.locality == null and include.location.region == null and include.location.country == null and include.location %}{{ include.location }}{% endif %}
+{% if include.location.locality == null and include.location.region == null and include.location.country == null and include.location.place %}{{ include.location.place }}{% endif %}
 {% endcapture %}{{ location_full | strip_newlines | replace:'  ',' ' | replace:'  ',' ' | replace:'  ',' ' | replace:'  ',' ' }}

--- a/_includes/location.html
+++ b/_includes/location.html
@@ -1,0 +1,10 @@
+{% capture location_full %}
+{% if include.location.locality %}
+{{ include.location.locality }}{% if include.location.region or include.location.country %}, {% endif %}
+{% endif %}
+{% if include.location.region %}
+{{ include.location.region }}{% if include.location.country %}, {% endif %}
+{% endif %}
+{% if include.location.country %}{{ include.location.country }}{% endif %}
+{% if include.location.locality == null and include.location.region == null and include.location.country == null and include.location %}{{ include.location }}{% endif %}
+{% endcapture %}{{ location_full | strip_newlines | replace:'  ',' ' | replace:'  ',' ' | replace:'  ',' ' | replace:'  ',' ' }}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -2,7 +2,7 @@
 <html class="wf-loading">
   <head>
     <meta charset="utf-8">
-    <title>{{ page.title }}{% if page.location %} in {{ page.location }}{% endif %}{% if page.title != null %} 🌏 {% endif %}{{ site.name }}</title>
+    <title>{{ page.title }}{% if page.location %} in {% include location.html location=page.location %}{% endif %}{% if page.title != null %} 🌏 {% endif %}{{ site.name }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="home" href="{{ site.url }}">
 
@@ -31,7 +31,7 @@
     <meta name="twitter:creator" content="@rupl">
     <meta property="og:type" content="website">
     <meta property="og:url" content="{{ site.url }}{{ page.url }}">
-    <meta property="og:title" content="{{ page.title | escape }}{% if page.location %} in {{ page.location | escape }}{% endif %}">
+    <meta property="og:title" content="{{ page.title | escape }}{% if page.location %} in {% include location.html location=page.location %}{% endif %}">
     <meta property="og:description" content="{{ page.summary | escape }}">
     <meta property="og:image" content="{{ site.url }}/img/travel/{% if page.gallery[0].src %}{{ page.gallery[0].src }}{% else %}{{ page.gallery[1].src }}{% endif %}">
   {% endif %}

--- a/_layouts/trip.html
+++ b/_layouts/trip.html
@@ -10,10 +10,8 @@ comments: true
     <h2 class="subtitle">
       <time class="dt-published" datetime="{{ page.date | date: "%Y-%m-%d" }}">{{ page.date | date: "%b %d, %Y" }}</time>
       {% if page.location %}
-        <span class="where">in
-        <span class="p-location h-adr">
+        <span class="where p-location h-adr">
           {% include location-microformat.html location=page.location %}
-        </span>
         </span>
       {% endif %}
     </h2>
@@ -33,7 +31,7 @@ comments: true
   {% if page.links != null %}
   <aside class="links">
     <h2 id="links" class="element-invisible">Links</h2>
-      <p>Here are some nice stops in {% include location.html location=page.location %}</p>
+      <p>Here are some nice stops {% include location.html location=page.location %}</p>
       <ul>
         {% for link in page.links %}
           <li><a class="type-{{ link.type }}" href="{{ link.href }}">{{ link.text }}</a></li>
@@ -44,11 +42,11 @@ comments: true
 
   <div class="go">
     {% if page.next.url %}
-      <a class="btn btn--next" href="{{ page.next.url }}" title="{{ page.next.title }}{% if page.next.location %} in {% include location.html location=page.next.location %}{% endif %}">Next trip</a>
+      <a class="btn btn--next" href="{{ page.next.url }}" title="{{ page.next.title }}{% if page.next.location %} {% include location.html location=page.next.location %}{% endif %}">Next trip</a>
     {% endif %}
     <a class="btn btn--back" href="/travel/">Travel</a>
     {% if page.previous.url %}
-      <a class="btn btn--prev" href="{{ page.previous.url }}" title="{{ page.previous.title }}{% if page.previous.location %} in {% include location.html location=page.previous.location %}{% endif %}">Prev trip</a>
+      <a class="btn btn--prev" href="{{ page.previous.url }}" title="{{ page.previous.title }}{% if page.previous.location %} {% include location.html location=page.previous.location %}{% endif %}">Prev trip</a>
     {% endif %}
     {% if page.comments %}
       <a id="comments-link" class="btn btn--comments" href="{{ site.url }}{{ page.url }}#disqus_thread" onclick="return loadDisqus(event);">Loading comment count...</a>

--- a/_layouts/trip.html
+++ b/_layouts/trip.html
@@ -9,7 +9,13 @@ comments: true
     <h1 class="title p-name">{{ page.title }}</h1>
     <h2 class="subtitle">
       <time class="dt-published" datetime="{{ page.date | date: "%Y-%m-%d" }}">{{ page.date | date: "%b %d, %Y" }}</time>
-      {% if page.location %}<span class="where">in <span class="p-location">{{ page.location }}</span></span>{% endif %}
+      {% if page.location %}
+        <span class="where">in
+        <span class="p-location h-adr">
+          {% include location-microformat.html location=page.location %}
+        </span>
+        </span>
+      {% endif %}
     </h2>
   </header>
 
@@ -27,7 +33,7 @@ comments: true
   {% if page.links != null %}
   <aside class="links">
     <h2 id="links" class="element-invisible">Links</h2>
-      <p>Here are some nice stops in {{ page.location }}</p>
+      <p>Here are some nice stops in {% include location.html location=page.location %}</p>
       <ul>
         {% for link in page.links %}
           <li><a class="type-{{ link.type }}" href="{{ link.href }}">{{ link.text }}</a></li>
@@ -38,11 +44,11 @@ comments: true
 
   <div class="go">
     {% if page.next.url %}
-      <a class="btn btn--next" href="{{ page.next.url }}" title="{{ page.next.title }}{% if page.next.location %} in {{ page.next.location }}{% endif %}">Next trip</a>
+      <a class="btn btn--next" href="{{ page.next.url }}" title="{{ page.next.title }}{% if page.next.location %} in {% include location.html location=page.next.location %}{% endif %}">Next trip</a>
     {% endif %}
     <a class="btn btn--back" href="/travel/">Travel</a>
     {% if page.previous.url %}
-      <a class="btn btn--prev" href="{{ page.previous.url }}" title="{{ page.previous.title }}{% if page.previous.location %} in {{ page.previous.location }}{% endif %}">Prev trip</a>
+      <a class="btn btn--prev" href="{{ page.previous.url }}" title="{{ page.previous.title }}{% if page.previous.location %} in {% include location.html location=page.previous.location %}{% endif %}">Prev trip</a>
     {% endif %}
     {% if page.comments %}
       <a id="comments-link" class="btn btn--comments" href="{{ site.url }}{{ page.url }}#disqus_thread" onclick="return loadDisqus(event);">Loading comment count...</a>

--- a/_posts/travel/2012-08-26-first-trip-to-freiburg.md
+++ b/_posts/travel/2012-08-26-first-trip-to-freiburg.md
@@ -1,6 +1,8 @@
 ---
 title: First trip to Freiburg
-location: Freiburg, Germany
+location:
+  locality: Freiburg
+  country: Germany
 
 gallery:
 - gridtype: tall

--- a/_posts/travel/2012-08-28-mussels-in-brussels.md
+++ b/_posts/travel/2012-08-28-mussels-in-brussels.md
@@ -1,6 +1,8 @@
 ---
 title: Mussels in Brussels
-location: Brussels, Belgium
+location:
+  locality: Brussels
+  country: Belgium
 layout: gallery
 
 gallery:

--- a/_posts/travel/2012-12-02-santiago-de-chile.md
+++ b/_posts/travel/2012-12-02-santiago-de-chile.md
@@ -1,6 +1,7 @@
 ---
 title: Visiting Karin
-location: Santiago de Chile
+location:
+  locality: Santiago de Chile
 layout: gallery
 
 gallery:

--- a/_posts/travel/2012-12-05-aconcagua-argentina.md
+++ b/_posts/travel/2012-12-05-aconcagua-argentina.md
@@ -1,6 +1,8 @@
 ---
 title: Cerro Aconcagua
-location: Mendoza, Argentina
+location:
+  locality: Mendoza
+  country: Argentina
 layout: gallery
 
 gallery:

--- a/_posts/travel/2012-12-06-mendoza-argentina.md
+++ b/_posts/travel/2012-12-06-mendoza-argentina.md
@@ -1,6 +1,8 @@
 ---
 title: Don't cry for me
-location: Mendoza, Argentina
+location:
+  locality: Mendoza
+  country: Argentina
 layout: gallery
 
 gallery:

--- a/_posts/travel/2012-12-09-bus-to-san-pedro.md
+++ b/_posts/travel/2012-12-09-bus-to-san-pedro.md
@@ -1,6 +1,8 @@
 ---
 title: Bus to San Pedro
-location: Salta, Argentina
+location:
+  locality: Salta
+  country: Argentina
 layout: gallery
 
 gallery:

--- a/_posts/travel/2012-12-10-downtown-san-pedro.md
+++ b/_posts/travel/2012-12-10-downtown-san-pedro.md
@@ -1,6 +1,8 @@
 ---
 title: Downtown
-location: San Pedro de Atacama, Chile
+location:
+  locality: San Pedro de Atacama
+  country: Chile
 layout: gallery
 
 gallery:

--- a/_posts/travel/2012-12-10-valle-de-la-muerte-y-luna.md
+++ b/_posts/travel/2012-12-10-valle-de-la-muerte-y-luna.md
@@ -1,6 +1,8 @@
 ---
 title: Valle de la Muerte y Luna
-location: San Pedro de Atacama, Chile
+location:
+  locality: San Pedro de Atacama
+  country: Chile
 
 gallery:
 - gridtype: col-3

--- a/_posts/travel/2012-12-11-san-pedro-salt-flats.md
+++ b/_posts/travel/2012-12-11-san-pedro-salt-flats.md
@@ -1,6 +1,8 @@
 ---
 title: Salt Flats
-location: San Pedro de Atacama, Chile
+location:
+  locality: San Pedro de Atacama
+  country: Chile
 layout: gallery
 
 gallery:

--- a/_posts/travel/2012-12-12-geysers-del-tatio.md
+++ b/_posts/travel/2012-12-12-geysers-del-tatio.md
@@ -1,6 +1,8 @@
 ---
 title: Geysers del Tatio
-location: San Pedro de Atacama, Chile
+location:
+  locality: San Pedro de Atacama
+  country: Chile
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-02-20-cape-town-table-mountain.md
+++ b/_posts/travel/2015-02-20-cape-town-table-mountain.md
@@ -1,6 +1,8 @@
 ---
 title: Setting the table
-location: Cape Town, South Africa
+location:
+  locality: Cape Town
+  country: South Africa
 
 gallery:
 - gridtype: col-3

--- a/_posts/travel/2015-02-25-cape-town-lions-head.md
+++ b/_posts/travel/2015-02-25-cape-town-lions-head.md
@@ -1,6 +1,8 @@
 ---
 title: Lion's Head
-location: Cape Town, South Africa
+location:
+  locality: Cape Town
+  country: South Africa
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-02-26-mossel-bay-south-africa.md
+++ b/_posts/travel/2015-02-26-mossel-bay-south-africa.md
@@ -1,6 +1,8 @@
 ---
 title: Relaxing on the beach
-location: Mossel Bay, South Africa
+location:
+  locality: Mossel Bay
+  country: South Africa
 
 map:
   location: Mossel Bay, South Africa

--- a/_posts/travel/2015-02-27-jeffreys-bay-south-africa.md
+++ b/_posts/travel/2015-02-27-jeffreys-bay-south-africa.md
@@ -1,6 +1,8 @@
 ---
 title: J-Bay
-location: "Jeffreys Bay, South Africa"
+location:
+  locality: Jeffreys Bay
+  country: South Africa
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-03-02-amakhala-game-reserve.md
+++ b/_posts/travel/2015-03-02-amakhala-game-reserve.md
@@ -1,6 +1,8 @@
 ---
 title: Amakhala Game Reserve
-location: Addo Elephant National Park
+location:
+  place: Addo Elephant National Park
+  prep: at
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-03-04-buccaneers-chintsa-south-africa.md
+++ b/_posts/travel/2015-03-04-buccaneers-chintsa-south-africa.md
@@ -1,6 +1,8 @@
 ---
 title: Buccaneers
-location: Cintsa Bay, South Africa
+location:
+  locality: Cintsa Bay
+  country: South Africa
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-06-06-graffiti-bristol-england.md
+++ b/_posts/travel/2015-06-06-graffiti-bristol-england.md
@@ -1,6 +1,8 @@
 ---
 title: Graffiti
-location: Bristol, England
+location:
+  locality: Bristol
+  country: England
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-07-04-val-maggia-switzerland.md
+++ b/_posts/travel/2015-07-04-val-maggia-switzerland.md
@@ -1,6 +1,8 @@
 ---
 title: Camping on the River
-location: Val Maggia, Switzerland
+location:
+  locality: Val Maggia
+  country: Switzerland
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-08-14-ann-arbor-michigan.md
+++ b/_posts/travel/2015-08-14-ann-arbor-michigan.md
@@ -1,6 +1,8 @@
 ---
 title: Visiting Friends
-location: Ann Arbor, Michigan
+location:
+  locality: Ann Arbor
+  region: Michigan
 
 gallery:
 - gridtype: col-3

--- a/_posts/travel/2015-08-24-cowtown-ft-worth-texas.md
+++ b/_posts/travel/2015-08-24-cowtown-ft-worth-texas.md
@@ -1,6 +1,8 @@
 ---
 title: Cowtown
-location: Fort Worth, Texas
+location:
+  locality: Fort Worth
+  region: Texas
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-09-18-visitors-in-freiburg.md
+++ b/_posts/travel/2015-09-18-visitors-in-freiburg.md
@@ -1,6 +1,8 @@
 ---
 title: Visitors
-location: Freiburg, Germany
+location:
+  locality: Freiburg
+  country: Germany
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-09-20-exploring-barcelona.md
+++ b/_posts/travel/2015-09-20-exploring-barcelona.md
@@ -1,6 +1,8 @@
 ---
 title: Exploring Barthelona
-location: Barcelona, Spain
+location:
+  locality: Barcelona
+  country: Spain
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-09-23-la-merce-barcelona.md
+++ b/_posts/travel/2015-09-23-la-merce-barcelona.md
@@ -1,6 +1,8 @@
 ---
 title: La Mercè
-location: Barcelona, Spain
+location:
+  locality: Barcelona
+  country: Spain
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-09-25-park-guell-barcelona.md
+++ b/_posts/travel/2015-09-25-park-guell-barcelona.md
@@ -1,6 +1,8 @@
 ---
 title: Parc Güell
-location: Barcelona, Spain
+location:
+  locality: Barcelona
+  country: Spain
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-10-04-hitting-the-road.md
+++ b/_posts/travel/2015-10-04-hitting-the-road.md
@@ -1,6 +1,8 @@
 ---
 title: Hitting the Road
-location: Freiburg, Germany
+location:
+  locality: Freiburg
+  country: Germany
 layout: quote
 
 quote:

--- a/_posts/travel/2015-10-05-paris-with-emily.md
+++ b/_posts/travel/2015-10-05-paris-with-emily.md
@@ -1,6 +1,8 @@
 ---
 title: Visiting Emily
-location: Paris, France
+location:
+  locality: Paris
+  country: France
 
 photosphere: paris-catacombs.jpg
 

--- a/_posts/travel/2015-10-07-versailles.md
+++ b/_posts/travel/2015-10-07-versailles.md
@@ -1,6 +1,8 @@
 ---
 title: The Palace
-location: Versailles, France
+location:
+  locality: Versailles
+  country: France
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-10-10-arriving-in-bangkok.md
+++ b/_posts/travel/2015-10-10-arriving-in-bangkok.md
@@ -1,6 +1,8 @@
 ---
 title: Arriving
-location: Bangkok, Thailand
+location:
+  locality: Bangkok
+  country: Thailand
 
 gallery:
 - gridtype: col-3

--- a/_posts/travel/2015-10-11-wat-pho.md
+++ b/_posts/travel/2015-10-11-wat-pho.md
@@ -1,6 +1,8 @@
 ---
 title: Wat Pho
-location: Bangkok, Thailand
+location:
+  locality: Bangkok
+  country: Thailand
 
 photosphere: wat-pho.jpg
 

--- a/_posts/travel/2015-10-14-bangkok-thailand.md
+++ b/_posts/travel/2015-10-14-bangkok-thailand.md
@@ -1,6 +1,8 @@
 ---
 title: Walking around
-location: Bangkok, Thailand
+location:
+  locality: Bangkok
+  country: Thailand
 
 photosphere: jim-thompson-house.jpg
 

--- a/_posts/travel/2015-10-16-ayothaya-riverside-house.md
+++ b/_posts/travel/2015-10-16-ayothaya-riverside-house.md
@@ -1,6 +1,8 @@
 ---
 title: Ayothaya Riverside House
-location: Ayutthaya, Thailand
+location:
+  locality: Ayutthaya
+  country: Thailand
 
 gallery:
 - gridtype: tall

--- a/_posts/travel/2015-10-17-temple-ruins-ayutthaya-thailand.md
+++ b/_posts/travel/2015-10-17-temple-ruins-ayutthaya-thailand.md
@@ -1,6 +1,8 @@
 ---
 title: Temple Ruins
-location: Ayutthaya, Thailand
+location:
+  locality: Ayutthaya
+  country: Thailand
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-10-20-chiang-mai-thailand.md
+++ b/_posts/travel/2015-10-20-chiang-mai-thailand.md
@@ -1,6 +1,8 @@
 ---
 title: City life
-location: Chiang Mai, Thailand
+location:
+  locality: Chiang Mai
+  country: Thailand
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-10-21-cave-lodge-thailand.md
+++ b/_posts/travel/2015-10-21-cave-lodge-thailand.md
@@ -1,6 +1,8 @@
 ---
 title: Cave Lodge
-location: Soppong, Thailand
+location:
+  locality: Soppong
+  country: Thailand
 
 gallery:
 - gridtype: tall

--- a/_posts/travel/2015-10-22-big-knob-cave-lodge.md
+++ b/_posts/travel/2015-10-22-big-knob-cave-lodge.md
@@ -1,6 +1,8 @@
 ---
 title: Big Knob
-location: Cave Lodge
+location:
+  place: Cave Lodge
+  prep: at
 
 map:
   kml: cave-lodge_big-knob.kml

--- a/_posts/travel/2015-10-22-big-knob-cave-lodge.md
+++ b/_posts/travel/2015-10-22-big-knob-cave-lodge.md
@@ -1,6 +1,6 @@
 ---
 title: Big Knob
-location: Soppong, Thailand
+location: Cave Lodge
 
 map:
   kml: cave-lodge_big-knob.kml

--- a/_posts/travel/2015-10-23-three-cave-trek-cave-lodge.md
+++ b/_posts/travel/2015-10-23-three-cave-trek-cave-lodge.md
@@ -1,6 +1,6 @@
 ---
 title: Three Cave Trek
-location: Soppong, Thailand
+location: Cave Lodge
 
 photosphere: xmas-cave.jpg
 

--- a/_posts/travel/2015-10-23-three-cave-trek-cave-lodge.md
+++ b/_posts/travel/2015-10-23-three-cave-trek-cave-lodge.md
@@ -1,6 +1,8 @@
 ---
 title: Three Cave Trek
-location: Cave Lodge
+location:
+  place: Cave Lodge
+  prep: at
 
 photosphere: xmas-cave.jpg
 

--- a/_posts/travel/2015-10-24-kayaking-cave-lodge.md
+++ b/_posts/travel/2015-10-24-kayaking-cave-lodge.md
@@ -1,6 +1,6 @@
 ---
 title: Kayaking
-location: Soppong, Thailand
+location: Cave Lodge
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-10-24-kayaking-cave-lodge.md
+++ b/_posts/travel/2015-10-24-kayaking-cave-lodge.md
@@ -1,6 +1,8 @@
 ---
 title: Kayaking
-location: Cave Lodge
+location:
+  place: Cave Lodge
+  prep: at
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-10-26-pai-thailand.md
+++ b/_posts/travel/2015-10-26-pai-thailand.md
@@ -1,6 +1,8 @@
 ---
 title: Chillin'
-location: Pai, Thailand
+location:
+  locality: Pai
+  country: Thailand
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-10-27-pai-waterfall.md
+++ b/_posts/travel/2015-10-27-pai-waterfall.md
@@ -1,6 +1,8 @@
 ---
 title: The waterfall
-location: Pai, Thailand
+location:
+  locality: Pai
+  country: Thailand
 
 gallery:
 - gridtype: tall

--- a/_posts/travel/2015-11-01-books-in-pai.md
+++ b/_posts/travel/2015-11-01-books-in-pai.md
@@ -1,6 +1,8 @@
 ---
 title: Books
-location: Pai, Thailand
+location:
+  locality: Pai
+  country: Thailand
 
 gallery:
 - gridtype: col-3

--- a/_posts/travel/2015-11-06-mr-christopher.md
+++ b/_posts/travel/2015-11-06-mr-christopher.md
@@ -1,6 +1,8 @@
 ---
 title: Mr. Christopher
-location: Pai, Thailand
+location:
+  locality: Pai
+  country: Thailand
 
 gallery:
 - gridtype: col-3

--- a/_posts/travel/2015-11-12-pai-cooking-class.md
+++ b/_posts/travel/2015-11-12-pai-cooking-class.md
@@ -1,6 +1,8 @@
 ---
 title: Cooking class
-location: Pai, Thailand
+location:
+  locality: Pai
+  country: Thailand
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-11-13-sabai-garden-pai.md
+++ b/_posts/travel/2015-11-13-sabai-garden-pai.md
@@ -1,6 +1,8 @@
 ---
 title: Sabai Garden
-location: Pai, Thailand
+location:
+  locality: Pai
+  country: Thailand
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-11-15-chiang-mai-part-2.md
+++ b/_posts/travel/2015-11-15-chiang-mai-part-2.md
@@ -1,6 +1,8 @@
 ---
 title: Walking around
-location: Chiang Mai, Thailand
+location:
+  locality: Chiang Mai
+  country: Thailand
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-11-16-arriving-in-vietnam.md
+++ b/_posts/travel/2015-11-16-arriving-in-vietnam.md
@@ -1,6 +1,8 @@
 ---
 title: Arriving
-location: Ho Chi Minh City, Vietnam
+location:
+  locality: Ho Chi Minh City
+  country: Vietnam
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-11-19-longson-mui-ne.md
+++ b/_posts/travel/2015-11-19-longson-mui-ne.md
@@ -1,6 +1,8 @@
 ---
 title: Longson
-location: Mui Ne, Vietnam
+location:
+  locality: Mui Ne
+  country: Vietnam
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-11-20-sandcastles-mui-ne.md
+++ b/_posts/travel/2015-11-20-sandcastles-mui-ne.md
@@ -1,8 +1,8 @@
 ---
 title: Sandcastles
 location:
-  locality: Mui Ne
-  country: Vietnam
+  place: Longson Mui Ne
+  prep: at
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-11-20-sandcastles-mui-ne.md
+++ b/_posts/travel/2015-11-20-sandcastles-mui-ne.md
@@ -1,6 +1,8 @@
 ---
 title: Sandcastles
-location: Mui Ne, Vietnam
+location:
+  locality: Mui Ne
+  country: Vietnam
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-11-21-mui-ne-sunrise-tour.md
+++ b/_posts/travel/2015-11-21-mui-ne-sunrise-tour.md
@@ -1,6 +1,8 @@
 ---
 title: Sunrise tour
-location: Mui Ne, Vietnam
+location:
+  locality: Mui Ne
+  country: Vietnam
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-11-25-easy-riders-day-1.md
+++ b/_posts/travel/2015-11-25-easy-riders-day-1.md
@@ -1,6 +1,8 @@
 ---
 title: Dalat Easy Riders Day 1
-location: Da Lat, Vietnam
+location:
+  locality: Da Lat
+  country: Vietnam
 
 map:
   kml: easy-rider-day-1.kml

--- a/_posts/travel/2015-11-26-easy-riders-day-2.md
+++ b/_posts/travel/2015-11-26-easy-riders-day-2.md
@@ -1,6 +1,8 @@
 ---
 title: Dalat Easy Riders Day 2
-location: Lak Lake, Vietnam
+location:
+  locality: Lak Lake
+  country: Vietnam
 
 map:
   kml: easy-rider-day-2.kml

--- a/_posts/travel/2015-11-27-easy-riders-day-3.md
+++ b/_posts/travel/2015-11-27-easy-riders-day-3.md
@@ -1,6 +1,8 @@
 ---
 title: Dalat Easy Riders Day 3
-location: Krong Kmar, Vietnam
+location:
+  locality: Krong Kmar
+  country: Vietnam
 
 map:
   kml: easy-rider-day-3.kml

--- a/_posts/travel/2015-11-28-nha-trang-vietnam.md
+++ b/_posts/travel/2015-11-28-nha-trang-vietnam.md
@@ -1,6 +1,8 @@
 ---
 title: Downtime
-location: Nha Trang, Vietnam
+location:
+  locality: Nha Trang
+  country: Vietnam
 
 gallery:
 - gridtype: col-3

--- a/_posts/travel/2015-12-01-hoi-an-vietnam.md
+++ b/_posts/travel/2015-12-01-hoi-an-vietnam.md
@@ -1,6 +1,8 @@
 ---
 title: Lantern market
-location: Hoi An, Vietnam
+location:
+  locality: Hoi An
+  country: Vietnam
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-12-07-dong-hoi-vietnam.md
+++ b/_posts/travel/2015-12-07-dong-hoi-vietnam.md
@@ -1,6 +1,8 @@
 ---
 title: Stopover
-location: Dong Hoi, Vietnam
+location:
+  locality: Dong Hoi
+  country: Vietnam
 
 summary: We stopped in Dong Hoi because we had the time and wanted to break up the bus ride to Hanoi.
 ---

--- a/_posts/travel/2015-12-08-ha-long-bay-vietnam.md
+++ b/_posts/travel/2015-12-08-ha-long-bay-vietnam.md
@@ -1,6 +1,8 @@
 ---
 title: Boat tour
-location: Ha Long Bay, Vietnam
+location:
+  locality: Ha Long Bay
+  country: Vietnam
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-12-09-hospital-cave-national-park.md
+++ b/_posts/travel/2015-12-09-hospital-cave-national-park.md
@@ -1,6 +1,8 @@
 ---
 title: Caves and Parks
-location: Cat Ba, Vietnam
+location:
+  locality: Cat Ba
+  country: Vietnam
 
 gallery:
 - gridtype: col-2-short

--- a/_posts/travel/2015-12-11-cat-ba-kayaking.md
+++ b/_posts/travel/2015-12-11-cat-ba-kayaking.md
@@ -1,6 +1,8 @@
 ---
 title: Kayaking
-location: Lan Ha Bay, Vietnam
+location:
+  locality: Lan Ha Bay
+  country: Vietnam
 
 map:
   kml: cat-ba-kayaking.kml

--- a/_posts/travel/2015-12-12-bus-from-hanoi-to-laos.md
+++ b/_posts/travel/2015-12-12-bus-from-hanoi-to-laos.md
@@ -1,6 +1,8 @@
 ---
 title: Bus to Laos
-location: Hanoi, Vietnam
+location:
+  locality: Hanoi
+  country: Vietnam
 
 gallery:
 - gridtype: col-3

--- a/_posts/travel/2015-12-14-muang-khua-laos.md
+++ b/_posts/travel/2015-12-14-muang-khua-laos.md
@@ -1,6 +1,8 @@
 ---
 title: Sabaidee
-location: Muang Khua, Laos
+location:
+  locality: Muang Khua
+  country: Laos
 
 gallery:
 - gridtype: tall

--- a/_posts/travel/2015-12-16-muang-khua-market.md
+++ b/_posts/travel/2015-12-16-muang-khua-market.md
@@ -1,6 +1,8 @@
 ---
 title: Markets
-location: Muang Khua, Laos
+location:
+  locality: Muang Khua
+  country: Laos
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-12-18-muang-ngoy-slowboat.md
+++ b/_posts/travel/2015-12-18-muang-ngoy-slowboat.md
@@ -1,6 +1,8 @@
 ---
 title: Slow boat to Muang Ngoy
-location: Muang Khua, Laos
+location:
+  locality: Muang Khua
+  country: Laos
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-12-19-muang-ngoy-laos.md
+++ b/_posts/travel/2015-12-19-muang-ngoy-laos.md
@@ -1,6 +1,8 @@
 ---
 title: Hiking
-location: Muang Ngoy, Laos
+location:
+  locality: Muang Ngoy
+  country: Laos
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-12-20-muang-ngoy-kayaking.md
+++ b/_posts/travel/2015-12-20-muang-ngoy-kayaking.md
@@ -1,6 +1,8 @@
 ---
 title: Kayaking to Nong Khiaw
-location: Muang Ngoy, Laos
+location:
+  locality: Muang Ngoy
+  country: Laos
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-12-22-nong-khiaw-phadeng-peak.md
+++ b/_posts/travel/2015-12-22-nong-khiaw-phadeng-peak.md
@@ -1,6 +1,8 @@
 ---
 title: Phadeng Peak
-location: Nong Khiaw, Laos
+location:
+  locality: Nong Khiaw
+  country: Laos
 
 photosphere: phadeng-peak.jpg
 

--- a/_posts/travel/2015-12-24-nong-khiaw-nang-none.md
+++ b/_posts/travel/2015-12-24-nong-khiaw-nang-none.md
@@ -1,6 +1,8 @@
 ---
 title: Nang None viewpoint
-location: Nong Khiaw, Laos
+location:
+  locality: Nong Khiaw
+  country: Laos
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-12-26-nong-khiaw-100-waterfalls.md
+++ b/_posts/travel/2015-12-26-nong-khiaw-100-waterfalls.md
@@ -1,6 +1,8 @@
 ---
 title: 100 Waterfalls
-location: Nong Khiaw, Laos
+location:
+  locality: Nong Khiaw
+  country: Laos
 
 gallery:
 - gridtype: col-3

--- a/_posts/travel/2015-12-28-luang-prabang-grill-buffet.md
+++ b/_posts/travel/2015-12-28-luang-prabang-grill-buffet.md
@@ -1,6 +1,8 @@
 ---
 title: Grill Buffet
-location: Luang Prabang, Laos
+location:
+  locality: Luang Prabang
+  country: Laos
 layout: gallery
 
 gallery:

--- a/_posts/travel/2015-12-31-vang-vieng-tubing.md
+++ b/_posts/travel/2015-12-31-vang-vieng-tubing.md
@@ -1,6 +1,8 @@
 ---
 title: Tubing
-location: Vang Vieng, Laos
+location:
+  locality: Vang Vieng
+  country: Laos
 layout: gallery
 
 gallery:

--- a/_posts/travel/2016-01-04-vang-vieng-balloon.md
+++ b/_posts/travel/2016-01-04-vang-vieng-balloon.md
@@ -1,6 +1,8 @@
 ---
 title: Hot Air Balloon
-location: Vang Vieng, Laos
+location:
+  locality: Vang Vieng
+  country: Laos
 layout: gallery
 
 gallery:

--- a/_posts/travel/2016-01-05-night-train-to-thailand.md
+++ b/_posts/travel/2016-01-05-night-train-to-thailand.md
@@ -1,6 +1,8 @@
 ---
 title: Night train to Thailand
-location: Vientiane, Laos
+location:
+  locality: Vientiane
+  country: Laos
 layout: gallery
 
 gallery:

--- a/_posts/travel/2016-01-06-ayutthaya-part-2.md
+++ b/_posts/travel/2016-01-06-ayutthaya-part-2.md
@@ -1,6 +1,8 @@
 ---
 title: Back again
-location: Ayutthaya, Thailand
+location:
+  locality: Ayutthaya
+  country: Thailand
 layout: gallery
 
 gallery:

--- a/_posts/travel/2016-01-09-bangkok-part-2.md
+++ b/_posts/travel/2016-01-09-bangkok-part-2.md
@@ -1,6 +1,8 @@
 ---
 title: Back again
-location: Bangkok, Thailand
+location:
+  locality: Bangkok
+  country: Thailand
 layout: gallery
 
 gallery:

--- a/_posts/travel/2016-01-14-singapore.md
+++ b/_posts/travel/2016-01-14-singapore.md
@@ -1,6 +1,7 @@
 ---
 title: Long layover
-location: Singapore
+location:
+  country: Singapore
 layout: gallery
 
 gallery:

--- a/_posts/travel/2016-01-15-bali-indonesia.md
+++ b/_posts/travel/2016-01-15-bali-indonesia.md
@@ -1,6 +1,8 @@
 ---
 title: Beach time
-location: Bali, Indonesia
+location:
+  region: Bali
+  country: Indonesia
 layout: gallery
 
 gallery:

--- a/_posts/travel/2016-01-16-balangan-beach-bali.md
+++ b/_posts/travel/2016-01-16-balangan-beach-bali.md
@@ -1,6 +1,8 @@
 ---
 title: Balangan Beach
-location: Kuta, Bali
+location:
+  locality: Kuta
+  region: Bali
 
 gallery:
 - gridtype: col-3

--- a/_posts/travel/2016-01-17-beach-sunset-kuta.md
+++ b/_posts/travel/2016-01-17-beach-sunset-kuta.md
@@ -1,6 +1,8 @@
 ---
 title: Kuta beach
-location: Kuta, Bali
+location:
+  locality: Kuta
+  region: Bali
 layout: gallery
 
 gallery:

--- a/_posts/travel/2016-01-18-padang-bay-white-sand.md
+++ b/_posts/travel/2016-01-18-padang-bay-white-sand.md
@@ -1,6 +1,8 @@
 ---
 title: White sand beach
-location: Padang Bay, Bali
+location:
+  locality: Padang Bay
+  region: Bali
 layout: gallery
 
 gallery:

--- a/_posts/travel/2016-01-20-tirta-gangga-pura-lempuyang.md
+++ b/_posts/travel/2016-01-20-tirta-gangga-pura-lempuyang.md
@@ -1,6 +1,8 @@
 ---
 title: Tirta Gangga & Pura Lempuyang
-location: Bali, Indonesia
+location:
+  region: Bali
+  country: Indonesia
 layout: gallery
 
 gallery:

--- a/_posts/travel/2016-01-21-goodtimes-gili-air.md
+++ b/_posts/travel/2016-01-21-goodtimes-gili-air.md
@@ -1,6 +1,8 @@
 ---
 title: Good times
-location: Gili Air, Indonesia
+location:
+  locality: Gili Air
+  country: Indonesia
 layout: gallery
 
 links:

--- a/_posts/travel/2016-01-24-snorkeling-gili-air.md
+++ b/_posts/travel/2016-01-24-snorkeling-gili-air.md
@@ -1,6 +1,8 @@
 ---
 title: Snorkeling
-location: Gili Air, Indonesia
+location:
+  locality: Gili Air
+  country: Indonesia
 
 gallery:
 - gridtype: col-3

--- a/travel/list.html
+++ b/travel/list.html
@@ -19,7 +19,7 @@ layout: page
         <h2 class="title">
           <time datetime="{{ trip.date | date: "%Y-%m-%d" }}">{{ trip.date | date: "%b %d, %Y" }}</time>
           <a href="{{ trip.url }}">{{ trip.title }}</a>
-          {% if trip.location %}<span class="where">in {{ trip.location }}</span>{% endif %}
+          {% if trip.location %}<span class="where">in {% include location.html location=trip.location %}</span>{% endif %}
         </h2>
       </article>
     {% endfor %}

--- a/travel/list.html
+++ b/travel/list.html
@@ -19,7 +19,7 @@ layout: page
         <h2 class="title">
           <time datetime="{{ trip.date | date: "%Y-%m-%d" }}">{{ trip.date | date: "%b %d, %Y" }}</time>
           <a href="{{ trip.url }}">{{ trip.title }}</a>
-          {% if trip.location %}<span class="where">in {% include location.html location=trip.location %}</span>{% endif %}
+          {% if trip.location %}<span class="where">{% include location.html location=trip.location %}</span>{% endif %}
         </h2>
       </article>
     {% endfor %}


### PR DESCRIPTION
Right now the `location` field of my travel posts is just a plain text field. But as I read more about [IndieWeb](http://indiewebify.me) I find myself wanting to mark things up with more detail. Other classes were easy to add to my templates, but to output a decent [h-adr](http://microformats.org/wiki/h-adr) for the travel posts, I'll need to convert `location` into an array holding several components:

* locality (city)
* region (state/province)
* country

An additional benefit would be when I get around to making a map with all the places, having structured data might make it nicer to feed stuff into MapBox.

### Todos

* [x] split field into subfields
* [x] alter `trip.html` template to include `h-adr`
* [x] add `prep` subfield to define the preposition to be used in the `.where` tags