### PR TITLE
:link: follow-up to #18

### DIFF
--- a/_includes/filed.html
+++ b/_includes/filed.html
@@ -1,5 +1,5 @@
 {% capture filed %}
-  <a rel="author" class="p-author" href="{{ site.url }}/about/">Chris</a> filed this <strong class="p-category">{{ include.categories }}</strong> entry
+  <a rel="author" class="p-author h-card" href="{{ site.url }}/about/">Chris</a> filed this <strong class="p-category">{{ include.categories }}</strong> entry
   {% if include.tags %}
     and tagged it
     <span class="tags">


### PR DESCRIPTION
[`h-entry` validator said](http://indiewebify.me/validate-h-entry/?url=https%3A%2F%2Fchrisruppel.com%2Ftravel%2Fblue-fire-kawah-ijen-java%2F):

> You’re marking up your post’s author as a string — add `h-card` to make it a full h-card!
>
> ```<a class="p-author h-card" href="your-url.com">Your Name</a>```