### PR TITLE
Fix entry ID parsing logic

### DIFF
--- a/_includes/gallery-list-item.html
+++ b/_includes/gallery-list-item.html
@@ -1,4 +1,4 @@
-<article class="trip--teaser teaser--gallery{% if include.trip.quote.text %} teaser--quote{% endif %}" id="{{ include.trip.path | replace: '_posts/travel/','' | replace: '.md','' }}">
+<article class="trip--teaser teaser--gallery{% if include.trip.quote.text %} teaser--quote{% endif %}" id="{{ include.trip.path | replace: 'travel/_posts/','' | replace: '.md','' }}">
   <h2 class="title">
     <time datetime="{{ include.trip.date | date: '%Y-%m-%d' }}">{{ include.trip.date | date: "%b %d, %Y" }}</time>
     <a rel="bookmark" href="{{ site.url }}{{ include.trip.url }}">{{ include.trip.title }}</a>

--- a/_layouts/trip.html
+++ b/_layouts/trip.html
@@ -2,7 +2,7 @@
 layout: page
 ---
 
-<article class="trip h-entry">
+<article class="trip h-entry" id="{{ page.path | replace: 'travel/_posts/','' | replace: '.md','' }}">
   <header>
     <h1 class="title p-name">{{ page.title }}</h1>
     <h2 class="subtitle">


### PR DESCRIPTION
Bug introduced during the migration for #25. I hardcoded the path of my codebase into the templating logic and did not update it. Nothing broke because the IDs are always read dynamically, but still I don't want slashes in the IDs.