### PR TITLE
Show saved content on the Offline screen

### DIFF
--- a/_js/_utils.js
+++ b/_js/_utils.js
@@ -1,4 +1,10 @@
 //
+// Variables shared across files.
+//
+var OFFLINE_ARTICLE_PREFIX = 'chrisruppel-offline--';
+
+
+//
 // bling.js but using both qS and qSA
 //
 window.$ = document.querySelector.bind(document);
@@ -15,6 +21,7 @@ NodeList.prototype.on = NodeList.prototype.addEventListener = function (name, fn
     elem.on(name, fn);
   });
 }
+
 
 //
 // Blur all form fields

--- a/_js/entry.js
+++ b/_js/entry.js
@@ -96,7 +96,7 @@
 
         // Open cache and save current assets. If the cache already exists it is
         // overwriting the existing files.
-        caches.open('chrisruppel-offline--' + currentPath).then(function(cache) {
+        caches.open(OFFLINE_ARTICLE_PREFIX + currentPath).then(function(cache) {
           var updateCache = cache.addAll(pageResources);
 
           // Update UI to indicate success.

--- a/_js/offline.js
+++ b/_js/offline.js
@@ -1,0 +1,33 @@
+(function () {
+  "use strict";
+
+  // Get all Cache entries for this user.
+  caches.keys().then(function(cacheNames) {
+    // Define these just once instead of in the loop.
+    var offlineContentList = $('#offline');
+    var offlineContentEntry = $('#offline-content');
+
+    return Promise.all(
+      // Loop through Cache entries.
+      cacheNames.map(function(cacheName) {
+        // Check if any have the offline article naming convention.
+        if (cacheName.indexOf(OFFLINE_ARTICLE_PREFIX) !== -1) {
+          // The cache name indicates that it was saved by the user.
+          var cacheEntry = document.createElement('li');
+          cacheEntry.innerHTML = '<a href="' + cacheName.split('--')[1] + '">' + cacheName.split('/')[2] + '</a>';
+
+          // Append to DOM.
+          if (!!offlineContentEntry) {
+            console.info('Service Worker: found user-cached content ' + cacheName);
+            offlineContentEntry.appendChild(cacheEntry);
+          }
+
+          // Set the offline box to display since we found something
+          if (!!offlineContentList) {
+            offlineContentList.classList.add('is-active');
+          }
+        }
+      })
+    );
+  });
+})();

--- a/_js/sw/service-worker.js
+++ b/_js/sw/service-worker.js
@@ -9,7 +9,7 @@ importScripts('/js/cache-polyfill.js');
 // Config
 var OFFLINE_ARTICLE_PREFIX = 'chrisruppel-offline--';
 var SW = {
-  cache_version: 'main_v1.7.2',
+  cache_version: 'main_v1.8.0',
   offline_assets: [
     '/',
     '/offline/',

--- a/_sass/partials/_offline.scss
+++ b/_sass/partials/_offline.scss
@@ -1,0 +1,11 @@
+#offline {
+  overflow: hidden;
+  height: 0;
+  max-height: 0;
+  transition: max-height 1.5s ease-in-out;
+
+  &.is-active {
+    height: auto;
+    max-height: 1000px;
+  }
+}

--- a/_sass/styles.scss
+++ b/_sass/styles.scss
@@ -24,6 +24,7 @@
 @import 'partials/syndication';
 @import 'partials/tag-list';
 @import 'partials/prism';
+@import 'partials/offline';
 
 // Media
 @import 'partials/media';

--- a/offline.html
+++ b/offline.html
@@ -7,11 +7,18 @@ permalink: /offline/
 
 <p>It seems like your internet connection has gone away...</p>
 
-<p>You can still browse around a bit, but only a few pages will work until your connection comes back:</p>
+<div id="offline">
+  <p>...however, you did save the following pages for offline viewing!</p>
+  <ul id="offline-content">
+    <!-- Filled in by SW -->
+  </ul>
+</div>
 
-  <div class="go">
-    <a class="btn" href="/" title="Home">Home</a>
-    <a class="btn" href="/work/" title="Work">Work</a>
-    <a class="btn" href="/about/" title="About">About</a>
-    <a class="btn" href="/travel/list/" title="Travel list">Travel list</a>
-  </div>
+<p>You can still browse around a bit, but only a few other pages will work until your connection comes back:</p>
+
+<div class="go">
+  <a class="btn" href="/" title="Home">Home</a>
+  <a class="btn" href="/work/" title="Work">Work</a>
+  <a class="btn" href="/about/" title="About">About</a>
+  <a class="btn" href="/travel/list/" title="Travel list">Travel list</a>
+</div>


### PR DESCRIPTION
Users can already save content for offline viewing, but there's nothing pointing them back to those URLs if they land somewhere else on the site while offline.

Providing a list of cached articles is easy and a huge UX win.