### PR TITLE
Improve offline image handling

### DIFF
--- a/_js/status.js
+++ b/_js/status.js
@@ -15,3 +15,13 @@ function displayMessage(message) {
   $('#message').innerText = message;
   $('#status').classList.add('displayed');
 }
+
+//
+// Append more text.
+//
+// Occasionally there are two events close in time which might want to notify
+// the user of something. Use this to change the message instead of overwriting.
+//
+function appendMessage(message) {
+  $('#message').innerText += ' ' + message;
+}

--- a/_sass/partials/_general.scss
+++ b/_sass/partials/_general.scss
@@ -58,6 +58,45 @@ footer[role="contentinfo"] {
 
 img {
   max-width: 100%;
+  height: auto;
+  min-height: 5em; // maybe this is a terrible idea?
+
+  // Only for broken images
+  line-height: 1.5;
+  background: white;
+  display: block;
+  position: relative;
+
+  // Style broken images using pseudos. Working images offer no pseudo-element
+  // so these styles only apply to broken or improperly loaded images.
+  //
+  // @see https://bitsofco.de/styling-broken-images/
+  &::before {
+    content: '';
+    display: block;
+    width: 100%;
+    height: 100%;
+    min-height: 5em;
+    border: 1px solid #bbb;
+    background: linear-gradient(to top left, #fff, #ddd);
+    border-radius: 3px;
+    position: absolute;
+  }
+
+  &::after {
+    content: 'Image: ' attr(alt);
+    display: block;
+    position: absolute;
+    font-style: italic;
+    top: .5em;
+    right: .5em;
+    bottom: .5em;
+    left: .5em;
+
+    @media (min-width: 500px) {
+      font-size: .8em;
+    }
+  }
 }
 
 .title--main {


### PR DESCRIPTION
Addresses two issues to improve image handling:

- #70 makes images optional during SW offline saves/updates
- #48 styles broken images regardless of reason, but particularly handy for offline articles whose images failed to save.