### PR TITLE
Add uncached path for latest blog posts

### DIFF
--- a/_includes/blog-latest.html
+++ b/_includes/blog-latest.html
@@ -1,0 +1,10 @@
+{% for post in site.categories.blog limit:5 %}
+  <article data-url="{{ site.url }}{{ post.url }}">
+    <header>
+      <h2 class="title--main">
+        <time datetime="{{ post.date | date: '%Y-%m-%d' }}">{{ post.date | date: "%b %d, %Y" }}</time>
+        <a href="{{ post.url }}">{{ post.title }}</a>
+      </h2>
+    </header>
+  </article>
+{% endfor %}

--- a/_js/front.js
+++ b/_js/front.js
@@ -4,27 +4,22 @@
   // TODO: instead of using data-autoupdate="true" populate the attribute with
   //       the path that should be requested, then the data-attribute can serve
   //       as both a flag and the argument for a generic function.
-  var calendar = $('#calendar[data-autoupdate=true]');
+  var blogList = $('#blog-list[data-autoupdate=true]');
 
-  // Load the contact form when an open slot is clicked.
-  $$('.available').on('click', function () {
-    $('.btn--mail').click();
-  });
-
-  // For users with SW, fetch latest calendar if available.
+  // For users with SW, fetch latest blog posts if available.
   // If user does not have SW, then they won't see cached HTML in the first place.
-  if (Modernizr.serviceworker && !!calendar) {
+  if (Modernizr.serviceworker && !!blogList) {
     // TODO: use value of data-autoupdate in this `fetch()`
-    fetch('/work/calendar/').then(function (data) {
+    fetch('/blog/latest/').then(function (data) {
       return data.text();
     }).then(function (text) {
-      calendar.innerHTML = text;
-      console.info('Updated calendar successfully.');
+      blogList.innerHTML = text;
+      console.info('Updated latest blog posts successfully.');
     }).catch(function (error) {
       var warning = document.createElement('aside');
       warning.classList.add('warning');
-      warning.innerHTML = '<p><em><strong>Note:</strong></em> This calendar might be slightly out of date.</p>';
-      calendar.appendChild(warning);
+      warning.innerHTML = '<p><em><strong>Note:</strong></em> This list might be slightly out of date.</p>';
+      blogList.appendChild(warning);
       console.error(error);
     });
   }

--- a/_sass/partials/_work.scss
+++ b/_sass/partials/_work.scss
@@ -58,6 +58,7 @@
 
   // Big-screen styles
   @media (min-width: 600px) {
+    margin-bottom: 2rem;
     flex-wrap: nowrap;
     --cal-radius: 7px;
 

--- a/blog/latest.html
+++ b/blog/latest.html
@@ -1,0 +1,4 @@
+---
+layout: null
+---
+{% include blog-latest.html %}

--- a/index.html
+++ b/index.html
@@ -21,16 +21,7 @@ bodyclass: page--front
 <section aria-labelledby="blog">
   <h1 id="blog" class="title--main">Latest posts</h1>
 
-  <div id="blog-list" class="blog-list">
-    {% for post in site.categories.blog limit:5 %}
-      <article data-url="{{ site.url }}{{ post.url }}">
-        <header>
-          <h2 class="title--main">
-            <time datetime="{{ post.date | date: '%Y-%m-%d' }}">{{ post.date | date: "%b %d, %Y" }}</time>
-            <a href="{{ post.url }}">{{ post.title }}</a>
-          </h2>
-        </header>
-      </article>
-    {% endfor %}
+  <div id="blog-list" class="blog-list" data-autoupdate="true">
+    {% include blog-latest.html %}
   </div>
 </section>

--- a/work/index.html
+++ b/work/index.html
@@ -20,7 +20,7 @@ bodyclass: page--work
 <p>However, I'm not only interested in bigger sites. Any site in need of frontend development is a job for me! Please contact me using the button below and we can start a conversation about your project.</p>
 <p>Want more info right away? <a href="/work/services/">Read about my services.</a></p>
 
-<div id="calendar">
+<div id="calendar" data-autoupdate="true">
   {% include calendar.html %}
 </div>
 


### PR DESCRIPTION
My homepage is cached by the SW and contains old data on first revisit after some time. Just like my availability calendar (#64), I need to create an HTML fragment of my latest posts and fetch it to ensure the front-page content is as fresh as possible.